### PR TITLE
Update macro.cfg - add BED_LEVELING macros

### DIFF
--- a/macro.cfg
+++ b/macro.cfg
@@ -14,7 +14,7 @@ gcode:
 #START_PRINT EXTRUDER_TEMP={material_print_temperature_layer_0} BED_TEMP={material_bed_temperature_layer_0}
 
 
-[gcode_macro START_PRINT]          # START_PRINT 
+[gcode_macro START_PRINT]          # START_PRINT
 gcode:
     {% set BED_TEMP = params.BED_TEMP|default(60)|float %}
     {% set EXTRUDER_TEMP = params.EXTRUDER_TEMP|default(190)|float %}
@@ -291,3 +291,33 @@ gcode:
       BEEP
  #     UPDATE_DELAYED_GCODE ID=DELAYED_PRINTER_OFF DURATION=60
  #     WLED_ON STRIP=roof PRESET=4
+
+ [gcode_macro BED_LEVELING]
+ description: Start Bed Leveling
+ gcode:
+   {% if 'PROBE_COUNT' in params|upper %}
+     {% set get_count = ('PROBE_COUNT=' + params.PROBE_COUNT) %}
+   {%else %}
+     {% set get_count = "" %}
+   {% endif %}
+   {% set bed_temp = params.BED_TEMP|default(60)|float %}
+   {% set extruder_temp = params.EXTRUDER_TEMP|default(220)|float %}
+   {% if printer.toolhead.homed_axes != "xyz" %}
+     G28
+   {% endif %}
+   # Wait for bed to reach temperature
+   M190 S{bed_temp}
+   # Set and wait for nozzle to reach temperature
+   M109 S{extruder_temp}
+   BED_MESH_CLEAR
+   ACCURATE_G28
+   M204 S1500
+   SET_VELOCITY_LIMIT ACCEL_TO_DECEL=1500
+   BED_MESH_CALIBRATE {get_count}
+   BED_MESH_OUTPUT
+   {% set y_park = printer.toolhead.axis_maximum.y/2 %}
+   {% set x_park = printer.toolhead.axis_maximum.x|float - 10.0 %}
+   G1 X{x_park} Y{y_park} F9000
+   M106 S0 ;Turn-off fan
+   M104 S0 ;Turn-off hotend
+   M140 S0 ;Turn-off bed


### PR DESCRIPTION
Adding new macros to run bed leveling. This macros allows to set probes, bed and extruder temperature as parameters. By default it uses settings from printer.cfg (probes - 5x5 points) and bed temperature at 60 degrees, extruder at 220 degrees.