### PR TITLE
Update printer.cfg for Klipper deprecated setting

### DIFF
--- a/printer.cfg
+++ b/printer.cfg
@@ -129,7 +129,7 @@ restart_method: command
 kinematics: cartesian
 max_velocity: 150
 max_accel: 3000
-max_accel_to_decel: 3000
+minimum_cruise_ratio: 0.5
 max_z_velocity: 50
 square_corner_velocity: 5.0
 max_z_accel: 500


### PR DESCRIPTION
Removed old deprecated setting:

'max_accel_to_decel: 3000'

To replace with as docs suggest:

'minimum_cruise_ratio: 0.5'